### PR TITLE
Add primary unit tracking

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "lua.targetVersion": "5.3"
+}

--- a/dispatchnotify/CHANGEMEconfig_dispatchnotify.lua
+++ b/dispatchnotify/CHANGEMEconfig_dispatchnotify.lua
@@ -124,7 +124,9 @@ local config = {
     --[[
         waypointFallbackEnabled: Fall back to postal if exact coordinates cannot be found (for self-generated calls)
     ]]
-    waypointFallbackEnabled = true
+    waypointFallbackEnabled = true,
+    postalSendTimer = 1500,
+    nearestPostalResourceName = "nearest-postal"
 }
 
 if config.enabled then

--- a/dispatchnotify/CHANGEMEconfig_dispatchnotify.lua
+++ b/dispatchnotify/CHANGEMEconfig_dispatchnotify.lua
@@ -126,7 +126,8 @@ local config = {
     ]]
     waypointFallbackEnabled = true,
     postalSendTimer = 1500,
-    nearestPostalResourceName = "nearest-postal"
+    nearestPostalResourceName = "nearest-postal",
+    requireOfficerInVehicleForTrack = true -- Should Officer have to be in vehicle to be tracked?
 }
 
 if config.enabled then

--- a/dispatchnotify/cl_dispatchnotify.lua
+++ b/dispatchnotify/cl_dispatchnotify.lua
@@ -16,6 +16,7 @@ local cur_blip = nil
 if pluginConfig.enabled then
 
     local gpsLock = true
+    local primaryUnitLock = true
     local lastPostal = nil
     local lastCoords = nil
 
@@ -80,6 +81,11 @@ if pluginConfig.enabled then
     RegisterCommand("togglegps", function(source, args, rawCommand)
         gpsLock = not gpsLock
         TriggerEvent("chat:addMessage", {args = {"^0[ ^2GPS ^0] ", ("GPS lock has been %s"):format(gpsLock and "enabled" or "disabled")}})
+    end)
+
+    RegisterCommand("toggleprimarylock", function(source, args, rawCommand)
+        primaryUnitLock = not primaryUnitLock
+        TriggerEvent("chat:addMessage", {args = {"^0[ ^2GPS ^0] ", ("Primary unit lock has been %s"):format(gpsLock and "enabled" or "disabled")}})
     end)
 
     function track()

--- a/dispatchnotify/cl_dispatchnotify.lua
+++ b/dispatchnotify/cl_dispatchnotify.lua
@@ -66,13 +66,12 @@ if pluginConfig.enabled then
         trackingID = nil
     end)
 
-    RegisterNetEvent("SonoranCAD::dispatchnotify:UpdateBlipPostition")
+    RegisterNetEvent("SonoranCAD::dispatchnotify:UpdateBlipPosition")
     AddEventHandler("SonoranCAD::dispatchnotify:UpdateBlipPosition", function(position)
         if blip ~= nil then
             RemoveBlip(blip)
         end
-        local c = GetEntityCoords(GetPlayerPed(-1), 1)
-        blip = AddBlipForCoord(location.x, location.y, location.z)
+        blip = AddBlipForCoord(position.x, position.y, position.z)
         SetBlipRoute(blip, true)
     end)
 
@@ -106,7 +105,7 @@ if pluginConfig.enabled then
                         TriggerServerEvent("SonoranCAD::dispatchnotify:UpdateCallPostal", postal, trackingID)
                         lastpostal = postal
                     end
-                    TriggerServerEvent("SonoranCAD::dispatchnotify:UpdatePostition", GetEntityCoords(GetPlayerPed(-1), 1), trackingID)
+                    TriggerServerEvent("SonoranCAD::dispatchnotify:UpdatePosition", GetEntityCoords(GetPlayerPed(-1), 1), trackingID)
                 end
                 Citizen.Wait(pluginConfig.postalSendTimer)
             end

--- a/dispatchnotify/cl_dispatchnotify.lua
+++ b/dispatchnotify/cl_dispatchnotify.lua
@@ -52,9 +52,12 @@ if pluginConfig.enabled then
 
     RegisterNetEvent("SonoranCAD::dispatchnotify:BeginTracking")
     AddEventHandler("SonoranCAD::dispatchnotify:BeginTracking", function(callID)
+        local oldTrackValue = trackingCall
         trackingCall = true
         trackingID = callID
-        track()
+        if not oldTrackValue then
+            track()
+        end
     end)
 
     RegisterNetEvent("SonoranCAD::dispatchnotify:StopTracking")

--- a/dispatchnotify/sv_dispatchnotify.lua
+++ b/dispatchnotify/sv_dispatchnotify.lua
@@ -297,7 +297,7 @@ if pluginConfig.enabled then
                     TriggerEvent("SonoranCAD::pushevents:UnitAttach", data, unit)
                 end
             end,
-            ["CALL_CLOSE"] = function() 
+            ["CALL_CLOSE"] = function()
                 local cache = GetCallCache()[dispatchData.callId]
                 if cache.units ~= nil then
                     for k, v in pairs(cache.units) do

--- a/dispatchnotify/sv_dispatchnotify.lua
+++ b/dispatchnotify/sv_dispatchnotify.lua
@@ -144,6 +144,7 @@ if pluginConfig.enabled then
     registerApiType("NEW_DISPATCH", "emergency")
     registerApiType("ATTACH_UNIT", "emergency")
     registerApiType("REMOVE_911", "emergency")
+    registerApiType("SET_CALL_POSTAL", "emergency")
     RegisterCommand(pluginConfig.respondCommandName, function(source, args, rawCommand)
         local source = tonumber(source)
         if not pluginConfig.enableUnitResponse then
@@ -249,6 +250,11 @@ if pluginConfig.enabled then
             elseif pluginConfig.waypointType == "postal" or pluginConfig.waypointFallbackEnabled then
                 if call.dispatch.postal ~= nil and call.dispatch.postal ~= "" then
                     TriggerClientEvent("SonoranCAD::dispatchnotify:SetGps", officerId, call.dispatch.postal)
+                    if call.dispatch.metaData ~= nil and call.dispatch.metaData.trackPrimary == "True" then
+                        if GetSourceByApiId(GetUnitCache()[call.dispatch.idents[1]].data.apiIds) == officerId then
+                            TriggerClientEvent("SonoranCAD::dispatchnotify:BeginTracking", officerId, call.dispatch.callId)
+                        end
+                    end
                 end
             end
         else
@@ -330,6 +336,9 @@ if pluginConfig.enabled then
             return
         end
         if officerId ~= nil and call ~= nil then
+            if call.dispatch.metaData.trackPrimary then
+                TriggerClientEvent("SonoranCAD::dispatchnotify:StopTracking", officerId)
+            end
             SendMessage("dispatch", officerId, ("You were detached from call %s."):format(call.dispatch.callId))
         end
     end)
@@ -350,6 +359,16 @@ if pluginConfig.enabled then
                 debugLog("couldn't find officer")
             end
         end
+    end)
+    RegisterServerEvent("SonoranCAD::dispatchnotify:UpdateCallPostal")
+    AddEventHandler("SonoranCAD::dispatchnotify:UpdateCallPostal", function(clpostal, callid)
+        local data = {}
+        data[1] = {
+            callId = callid,
+            postal = clpostal,
+            serverId = Config.serverId
+        }
+        performApiRequest(data, 'SET_CALL_POSTAL', function() end)
     end)
 end
 

--- a/dispatchnotify/sv_dispatchnotify.lua
+++ b/dispatchnotify/sv_dispatchnotify.lua
@@ -304,12 +304,10 @@ if pluginConfig.enabled then
                         local officerId = GetUnitById(v.id)
                         if officerId ~= nil then
                             TriggerClientEvent("SonoranCAD::dispatchnotify:CallClosed", officerId, cache.callId)
-                            if call.dispatch.metaData.trackPrimary == "True" then
-                                if k == 1 then
-                                    TriggerClientEvent("SonoranCAD::dispatchnotify:StopTracking", officerId)
-                                else
-                                    TriggerClientEvent("SonoranCAD::dispatchnotify:RemoveBlip", officerId)
-                                end
+                            if k == 1 then
+                                TriggerClientEvent("SonoranCAD::dispatchnotify:StopTracking", officerId)
+                            else
+                                TriggerClientEvent("SonoranCAD::dispatchnotify:RemoveBlip", officerId)
                             end
                         end
                     end
@@ -334,6 +332,22 @@ if pluginConfig.enabled then
         end
         if before.address ~= after.address then
             TriggerEvent("SonoranCAD::dispatchnotify:CallEdit:Address", after.dispatch.callId, after.dispatch.address)
+        end
+        if before.dispatch.metaData.trackPrimary ~= "True" and after.dispatch.metaData.trackPrimary == "True" then
+            if #after.dispatch.idents > 0 then
+                TriggerClientEvent("SonoranCAD::dispatchnotify:BeginTracking", GetSourceByApiId(GetUnitCache()[after.dispatch.idents[1]].data.apiIds), after.dispatch.callId)
+            end
+        elseif before.dispatch.metaData.trackPrimary == "True" and after.dispatch.metaData.trackPrimary ~= "True" then
+            if #before.dispatch.idents > 0 then
+                TriggerClientEvent("SonoranCAD::dispatchnotify:StopTracking", GetSourceByApiId(GetUnitCache()[before.dispatch.idents[1]].data.apiIds))
+                for k, id in pairs(before.dispatch.idents) do
+                    if k ~= 1 then
+                        local unit = GetUnitCache()[GetUnitById(id)]
+                        local officerId = GetSourceByApiId(unit.data.apiIds)
+                        TriggerClientEvent("SonoranCAD::dispatchnotify:RemoveBlip", officerId)
+                    end
+                end
+            end
         end
     end)
 

--- a/dispatchnotify/version_dispatchnotify.json
+++ b/dispatchnotify/version_dispatchnotify.json
@@ -1,7 +1,7 @@
 {
     "version": "2.0.1",
     "check_url": "https://raw.githubusercontent.com/Sonoran-Software/sonoran_dispatchnotify/master/dispatchnotify/version_dispatchnotify.json",
-    "download_url": "https://github.com/Sonoran-Software/sonoran_dispatchnotify/releases",
+    "download_url": "https://github.com/Sonoran-Software/sonoran_dispatchnotify/",
     "configVersion": "2.0",
     "minCoreVersion": "2.5.7",
     "pluginDepends": [{ "name": "locations", "version": "1.3.1", "critical": true }, { "name": "callcommands", "version": "1.3.2", "critical": true }]


### PR DESCRIPTION
There are still a few more things to be added, such as a command to set yourself as the primary unit on your current call.